### PR TITLE
added register error messages and modified auth.css

### DIFF
--- a/src/.gitignore
+++ b/src/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+/keys*/
+/*.key
+/test*

--- a/src/.gitignore
+++ b/src/.gitignore
@@ -2,3 +2,4 @@ node_modules
 /keys*/
 /*.key
 /test*
+/*.db

--- a/src/public/css/auth.css
+++ b/src/public/css/auth.css
@@ -2,6 +2,12 @@ h1, p {
 	font-family: 'Roboto', sans-serif;
 }
 
+#content{
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+}
 #message {
 	padding: 20px;
+	max-width: 30em;
 }

--- a/src/public/script/register.js
+++ b/src/public/script/register.js
@@ -24,6 +24,7 @@ const sendForm = () => {
 	}, { withCredentials: true }).then((response) => {
 		const data = response.data;
 		const opcode = data.Opcode;
+		console.log('opcode register', opcode);
 		const message = data.Message;
 
 		switch(opcode)

--- a/src/public/script/register.js
+++ b/src/public/script/register.js
@@ -24,7 +24,6 @@ const sendForm = () => {
 	}, { withCredentials: true }).then((response) => {
 		const data = response.data;
 		const opcode = data.Opcode;
-		console.log('opcode register', opcode);
 		const message = data.Message;
 
 		switch(opcode)

--- a/src/server.js
+++ b/src/server.js
@@ -66,7 +66,7 @@ const init = async () => {
 		log(`User sent account creation request for account '${username}'`)
 
 		if (!validUsername(username)) {
-			const message = 'User account username was not valid'
+			const message = 'User account username was not valid. It can only contain alphanumerical or underscore characters. It\'s length must be between 2 and 20.'
 			log(warning(message));
 			res.json({ 
 				Opcode: RegisterOpcode.InvalidUserNameOrPassword,
@@ -76,7 +76,7 @@ const init = async () => {
 		}
 
 		if (!validPassword(password)) {
-			const message = 'User account password was not valid'
+			const message = 'User account password was not valid because it\'s length is either below 5 or above 200.'
 			log(warning(message));
 			res.json({ 
 				Opcode: RegisterOpcode.InvalidUserNameOrPassword,
@@ -267,7 +267,7 @@ const validEmail = (email) => {
 }
 
 const validUsername = (username) => {
-	if (!/[a-zA-Z0-9_]/.test(username) || username === "") {
+	if (!(/^[a-zA-Z0-9_]*$/.test(username)) || username === "") {
 		return false
 	}
 

--- a/src/server.js
+++ b/src/server.js
@@ -66,7 +66,7 @@ const init = async () => {
 		log(`User sent account creation request for account '${username}'`)
 
 		if (!validUsername(username)) {
-			const message = 'User account username was not valid. It can only contain alphanumerical or underscore characters. It\'s length must be between 2 and 20.'
+			const message = 'Username can only contain alphanumerical and underscore characters and its length must be between 2 and 20 characters.'
 			log(warning(message));
 			res.json({ 
 				Opcode: RegisterOpcode.InvalidUserNameOrPassword,
@@ -76,7 +76,7 @@ const init = async () => {
 		}
 
 		if (!validPassword(password)) {
-			const message = 'User account password was not valid because it\'s length is either below 5 or above 200.'
+			const message = 'Password length must be between 5 and 200 characters.'
 			log(warning(message));
 			res.json({ 
 				Opcode: RegisterOpcode.InvalidUserNameOrPassword,


### PR DESCRIPTION
When a user registers for an account, the website will display better error messages. They are:

`User account username was not valid. It can only contain alphanumerical or underscore characters. It's length must be between 2 and 20.`
`User account password was not valid because it\'s length is either below 5 or above 200.`

I adjusted the CSS so that the error message doesn't exceed a certain width.


